### PR TITLE
feat(ui): make app fully mobile responsive

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,9 +38,9 @@ function App() {
       {/* Immersive timeline stage */}
       <section className="relative bg-white">
         {/* Navy logo gutter (top-left, overlays the white stage) */}
-        <div className="absolute top-0 left-0 z-20 bg-navy-nma text-white px-4 w-40 h-16 flex flex-col justify-center">
-          <div className="text-[10px] tracking-widest uppercase opacity-70 leading-tight">The</div>
-          <div className="font-bold leading-tight text-sm">Chronicle of Light</div>
+        <div className="absolute top-0 left-0 z-20 bg-navy-nma text-white px-3 sm:px-4 w-24 sm:w-40 h-12 sm:h-16 flex flex-col justify-center">
+          <div className="text-[9px] sm:text-[10px] tracking-widest uppercase opacity-70 leading-tight">The</div>
+          <div className="font-bold leading-tight text-[11px] sm:text-sm">Chronicle of Light</div>
         </div>
 
         <TimelineView
@@ -55,8 +55,8 @@ function App() {
 
       {/* Secondary content section */}
       <section className="bg-panel">
-        <div className="container mx-auto p-6 space-y-8">
-          <header className="border-b border-slate-200 pb-4">
+        <div className="container mx-auto p-4 sm:p-6 space-y-6 sm:space-y-8">
+          <header className="border-b border-slate-200 pb-3 sm:pb-4">
             <h2 className="text-xs uppercase tracking-widest text-slate-500">Explore further</h2>
           </header>
 
@@ -71,7 +71,7 @@ function App() {
             setDateRange={setDateRange}
           />
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
             <MapView
               incidents={incidents}
               onIncidentClick={handleIncidentClick}
@@ -86,7 +86,7 @@ function App() {
 
           <div>
             <h3 className="text-sm font-semibold text-slate-700 mb-3">All moments</h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4">
               {incidents.map((incident) => (
                 <IncidentCard
                   key={incident.id}

--- a/src/components/common/FilterBar.tsx
+++ b/src/components/common/FilterBar.tsx
@@ -22,8 +22,8 @@ export const FilterBar: React.FC<FilterBarProps> = ({
   setDateRange,
 }) => {
   return (
-    <div className="bg-white border border-slate-200 rounded-md p-4">
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+    <div className="bg-white border border-slate-200 rounded-md p-3 sm:p-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3">
         <select
           value={selectedCategory || ''}
           onChange={(e) => setSelectedCategory(e.target.value || null)}

--- a/src/components/common/IncidentDetailModal.tsx
+++ b/src/components/common/IncidentDetailModal.tsx
@@ -55,14 +55,14 @@ export const IncidentDetailModal: React.FC<IncidentDetailModalProps> = ({
       <button
         onClick={onClose}
         aria-label="Close detail panel"
-        className="absolute top-6 right-6 w-10 h-10 rounded-full border border-slate-300 text-slate-600 hover:bg-slate-100 flex items-center justify-center transition-colors z-10"
+        className="fixed sm:absolute top-3 sm:top-6 right-3 sm:right-6 w-9 h-9 sm:w-10 sm:h-10 rounded-full border border-slate-300 bg-white/95 backdrop-blur-sm text-slate-600 hover:bg-slate-100 flex items-center justify-center transition-colors z-20"
       >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <path d="M6 6L18 18M6 18L18 6" />
         </svg>
       </button>
 
-      <div className="max-w-6xl mx-auto px-8 md:px-16 py-16 grid md:grid-cols-2 gap-12">
+      <div className="max-w-6xl mx-auto px-4 sm:px-8 md:px-16 py-8 sm:py-12 md:py-16 grid md:grid-cols-2 gap-6 sm:gap-8 md:gap-12">
         <figure>
           {heroUrl ? (
             <img
@@ -89,12 +89,12 @@ export const IncidentDetailModal: React.FC<IncidentDetailModalProps> = ({
 
           <h2
             id="incident-headline"
-            className="text-3xl md:text-4xl font-semibold text-teal-nma mb-6"
+            className="text-2xl sm:text-3xl md:text-4xl font-semibold text-teal-nma mb-4 sm:mb-6"
           >
             {incident.title}
           </h2>
 
-          <p className="text-base text-slate-700 leading-relaxed mb-8">
+          <p className="text-sm sm:text-base text-slate-700 leading-relaxed mb-6 sm:mb-8">
             {incident.description}
           </p>
 
@@ -102,7 +102,7 @@ export const IncidentDetailModal: React.FC<IncidentDetailModalProps> = ({
             type="button"
             disabled
             title="Article page coming soon"
-            className="bg-teal-nma hover:bg-teal-nma/90 disabled:bg-slate-300 disabled:cursor-not-allowed text-white text-xs font-semibold tracking-wider uppercase px-6 py-3 rounded-full transition-colors"
+            className="bg-teal-nma hover:bg-teal-nma/90 disabled:bg-slate-300 disabled:cursor-not-allowed text-white text-[11px] sm:text-xs font-semibold tracking-wider uppercase px-5 sm:px-6 py-2.5 sm:py-3 rounded-full transition-colors"
           >
             Read more about this moment
           </button>

--- a/src/components/graph/GraphView.tsx
+++ b/src/components/graph/GraphView.tsx
@@ -126,11 +126,11 @@ export const GraphView: React.FC<GraphViewProps> = ({
   }, [data]);
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-4 h-96 flex flex-col">
-      <div className="flex items-baseline justify-between mb-3">
-        <h2 className="text-2xl font-bold">Event Connections</h2>
-        <span className="text-xs text-slate-500">
-          drag to rotate · scroll to zoom · right-click to pan
+    <div className="bg-white rounded-lg shadow-md p-3 sm:p-4 h-80 sm:h-96 flex flex-col">
+      <div className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between mb-2 sm:mb-3 gap-1">
+        <h2 className="text-lg sm:text-2xl font-bold">Event Connections</h2>
+        <span className="text-[11px] sm:text-xs text-slate-500">
+          drag to rotate · pinch / scroll to zoom
         </span>
       </div>
       <div

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -23,9 +23,9 @@ export const MapView: React.FC<MapViewProps> = ({
   });
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-4">
-      <h2 className="text-2xl font-bold mb-4">Map</h2>
-      <div className="h-96 rounded">
+    <div className="bg-white rounded-lg shadow-md p-3 sm:p-4">
+      <h2 className="text-lg sm:text-2xl font-bold mb-3 sm:mb-4">Map</h2>
+      <div className="h-64 sm:h-80 lg:h-96 rounded">
         <MapContainer
           center={[30, 45]}
           zoom={3}

--- a/src/components/timeline/TimelineTopBar.tsx
+++ b/src/components/timeline/TimelineTopBar.tsx
@@ -38,11 +38,11 @@ export const TimelineTopBar: React.FC<TimelineTopBarProps> = ({
   const buttonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
 
   return (
-    <div className="relative bg-white border-b border-slate-200 h-16 flex items-start pl-44 pr-14 pt-3">
+    <div className="relative bg-white border-b border-slate-200 h-12 sm:h-16 flex items-start pl-28 sm:pl-44 pr-6 sm:pr-14 pt-2 sm:pt-3 overflow-x-auto">
       <nav
         role="navigation"
         aria-label="Era navigation"
-        className="flex items-start space-x-8 whitespace-nowrap"
+        className="flex items-start space-x-4 sm:space-x-8 whitespace-nowrap"
       >
         {ERA_MARKERS.map((era, idx) => {
           const isActive = selectedEra === era.year;
@@ -68,7 +68,7 @@ export const TimelineTopBar: React.FC<TimelineTopBarProps> = ({
                   }
                 }}
                 aria-pressed={isActive}
-                className={`text-[15px] font-medium transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-slate-900 ${
+                className={`text-[13px] sm:text-[15px] font-medium transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-slate-900 ${
                   isActive
                     ? 'text-slate-900'
                     : 'text-slate-600 hover:text-slate-900'

--- a/src/components/timeline/TimelineView.tsx
+++ b/src/components/timeline/TimelineView.tsx
@@ -1,7 +1,12 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { HistoricalIncident } from '../../types/incident';
 import { TimelineTopBar } from './TimelineTopBar';
 import './timeline.css';
+
+const MOBILE_BREAKPOINT = 768;
+const MOBILE_CARD_SCALE = 0.65;
+const MOBILE_PX_PER_YEAR_SCALE = 0.7;
+const MOBILE_ERA_BASE_WIDTH = 110;
 
 interface TimelineViewProps {
   incidents: HistoricalIncident[];
@@ -63,8 +68,14 @@ const CARD_VARIANTS: CardVariant[] = [
 const hashString = (s: string): number =>
   Math.abs([...s].reduce((acc, c) => (acc * 31 + c.charCodeAt(0)) | 0, 7));
 
-const variantFor = (id: string): CardVariant =>
-  CARD_VARIANTS[hashString(id) % CARD_VARIANTS.length];
+const variantFor = (id: string, scale = 1): CardVariant => {
+  const base = CARD_VARIANTS[hashString(id) % CARD_VARIANTS.length];
+  if (scale === 1) return base;
+  return {
+    width: Math.round(base.width * scale),
+    height: Math.round(base.height * scale),
+  };
+};
 
 const ERA_BASE_WIDTH = 200;
 // Pixels of horizontal space per year of elapsed time. Controls visual density.
@@ -102,7 +113,7 @@ interface PlacedCard {
 // which one lets it sit nearest to that ideal X without colliding with the
 // previous card in the chosen lane. Layout is fully data-driven: any new event
 // slots in automatically by its startDate.
-function placeEra(events: HistoricalIncident[]): {
+function placeEra(events: HistoricalIncident[], cardScale = 1): {
   placed: PlacedCard[];
   width: number;
 } {
@@ -115,16 +126,19 @@ function placeEra(events: HistoricalIncident[]): {
   );
   const firstYear = fractionalYear(sorted[0].startDate);
 
+  const pxPerYear = PX_PER_YEAR * (cardScale === 1 ? 1 : MOBILE_PX_PER_YEAR_SCALE);
+  const laneGap = Math.round(LANE_GAP * (cardScale === 1 ? 1 : MOBILE_PX_PER_YEAR_SCALE));
+
   const placed: PlacedCard[] = [];
   let lastTopRight = -Infinity;
   let lastBotRight = -Infinity;
 
   for (const event of sorted) {
-    const idealX = (fractionalYear(event.startDate) - firstYear) * PX_PER_YEAR;
-    const width = variantFor(event.id).width;
+    const idealX = (fractionalYear(event.startDate) - firstYear) * pxPerYear;
+    const width = variantFor(event.id, cardScale).width;
 
-    const nextXTop = Math.max(idealX, lastTopRight + LANE_GAP);
-    const nextXBot = Math.max(idealX, lastBotRight + LANE_GAP);
+    const nextXTop = Math.max(idealX, lastTopRight + laneGap);
+    const nextXBot = Math.max(idealX, lastBotRight + laneGap);
 
     // Choose the lane that lets us sit closest to idealX (= smallest nextX).
     // Ties resolve toward the less-used lane so cards naturally alternate.
@@ -164,13 +178,14 @@ const formatProseDate = (iso: string): string => {
 interface CardProps {
   incident: HistoricalIncident;
   onClick: (incident: HistoricalIncident) => void;
+  cardScale?: number;
 }
 
-const TimelineCard: React.FC<CardProps> = ({ incident, onClick }) => {
+const TimelineCard: React.FC<CardProps> = ({ incident, onClick, cardScale = 1 }) => {
   const imageMedia = incident.media?.find((m) => m.type === 'image');
   const imageUrl = imageMedia?.url;
   const date = formatProseDate(incident.startDate);
-  const { width, height } = variantFor(incident.id);
+  const { width, height } = variantFor(incident.id, cardScale);
   const sizeStyle: React.CSSProperties = { width, height };
 
   if (imageUrl) {
@@ -213,6 +228,20 @@ export const TimelineView: React.FC<TimelineViewProps> = ({
 }) => {
   const scrollerRef = useRef<HTMLDivElement>(null);
   const eraRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const [isMobile, setIsMobile] = useState<boolean>(
+    typeof window !== 'undefined' && window.innerWidth < MOBILE_BREAKPOINT,
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const handle = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    setIsMobile(mq.matches);
+    mq.addEventListener('change', handle);
+    return () => mq.removeEventListener('change', handle);
+  }, []);
+
+  const cardScale = isMobile ? MOBILE_CARD_SCALE : 1;
+  const eraBaseWidth = isMobile ? MOBILE_ERA_BASE_WIDTH : ERA_BASE_WIDTH;
 
   const grouped = useMemo(() => {
     return ERAS.map((era) => ({
@@ -232,10 +261,10 @@ export const TimelineView: React.FC<TimelineViewProps> = ({
     const scroller = scrollerRef.current;
     if (!target || !scroller) return;
     scroller.scrollTo({
-      left: target.offsetLeft - 80,
+      left: target.offsetLeft - (isMobile ? 32 : 80),
       behavior: 'smooth',
     });
-  }, [selectedEra]);
+  }, [selectedEra, isMobile]);
 
   return (
     <div className="relative w-full bg-white">
@@ -257,8 +286,8 @@ export const TimelineView: React.FC<TimelineViewProps> = ({
           </div>
 
           {grouped.map((era) => {
-            const { placed, width: tracksWidth } = placeEra(era.incidents);
-            const eraWidth = ERA_BASE_WIDTH + tracksWidth;
+            const { placed, width: tracksWidth } = placeEra(era.incidents, cardScale);
+            const eraWidth = eraBaseWidth + tracksWidth;
 
             return (
               <div
@@ -281,6 +310,7 @@ export const TimelineView: React.FC<TimelineViewProps> = ({
                       <TimelineCard
                         incident={p.incident}
                         onClick={onIncidentClick}
+                        cardScale={cardScale}
                       />
                     </div>
                   ))}

--- a/src/components/timeline/TimelineView.tsx
+++ b/src/components/timeline/TimelineView.tsx
@@ -235,7 +235,6 @@ export const TimelineView: React.FC<TimelineViewProps> = ({
   useEffect(() => {
     const mq = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
     const handle = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    setIsMobile(mq.matches);
     mq.addEventListener('change', handle);
     return () => mq.removeEventListener('change', handle);
   }, []);

--- a/src/components/timeline/timeline.css
+++ b/src/components/timeline/timeline.css
@@ -20,6 +20,14 @@
   background: #ffffff;
 }
 
+@media (max-width: 767px) {
+  .timeline-stage {
+    height: 440px;
+    padding-left: 96px;
+    padding-right: 32px;
+  }
+}
+
 /* Continuous dashed rail running through the vertical centerline */
 .timeline-rail {
   position: absolute;
@@ -31,6 +39,12 @@
   transform: translateY(-50%);
   pointer-events: none;
   z-index: 1;
+}
+
+@media (max-width: 767px) {
+  .timeline-rail {
+    left: 96px;
+  }
 }
 
 .timeline-scroll-hint {
@@ -49,6 +63,18 @@
   gap: 6px;
   background: #ffffff;
   padding: 4px 8px;
+}
+
+@media (max-width: 767px) {
+  .timeline-scroll-hint {
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    padding: 3px 6px;
+    gap: 4px;
+  }
+  .timeline-scroll-hint-arrow {
+    font-size: 14px;
+  }
 }
 
 .timeline-scroll-hint-arrow {
@@ -80,6 +106,13 @@
   padding: 0 20px;
   background: #ffffff;
   align-self: center;
+}
+
+@media (max-width: 767px) {
+  .timeline-era-label {
+    font-size: 32px;
+    padding: 0 10px;
+  }
 }
 
 .timeline-era-tracks {
@@ -215,6 +248,25 @@
   font-size: 13px;
   color: #64748b;
   margin-top: 12px;
+}
+
+@media (max-width: 767px) {
+  .timeline-card-image-overlay {
+    padding: 10px;
+  }
+  .timeline-card-image-date,
+  .timeline-card-text-date {
+    font-size: 11px;
+    margin-top: 8px;
+  }
+  .timeline-card-image-title,
+  .timeline-card-text-title {
+    font-size: 13px;
+    line-height: 1.25;
+  }
+  .timeline-card--text {
+    padding: 12px 14px;
+  }
 }
 
 /* ============================================================


### PR DESCRIPTION
Add mobile breakpoints across timeline, map, graph, filter bar, and detail modal. Timeline scales card sizes and horizontal spacing to 65-70% under 768px, shrinks stage height (620→440px), era label (64→32px), and top bar padding so the horizontal-scrolling layout stays usable on phones.

## Description

Briefly describe what this PR does.

## Type of Change

- [ ] Add new event(s)
- [ ] Correct existing event(s)
- [ ] Add connections between events
- [ ] Code change / feature
- [ ] Bug fix
- [ ] Documentation update

## Event Changes (if applicable)

| Event ID | Action | Notes |
|---|---|---|
| `event-XXXX-...` | Added / Edited / Connected | Brief note |

## Sources

For new or corrected events, list the sources you used:

1.
2.

## Checklist

- [ ] I've run `npm run validate:events` locally
- [ ] Event IDs follow the `event-YYYY-slug` format
- [ ] Filenames match their `id` fields
- [ ] Years are 4-digit zero-padded (e.g., `0624`)
- [ ] `connections[]` IDs reference existing events
- [ ] Sources are cited for new events
